### PR TITLE
Drop GHCR_USERNAME and GHCR_PASSWORD

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,9 @@ on:
     - 'v*'
   pull_request:
 
+permissions:
+  packages: read
+
 jobs:
   runtime:
     runs-on: ubuntu-latest
@@ -24,8 +27,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -65,8 +68,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -110,8 +113,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -155,8 +158,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -200,8 +203,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -245,8 +248,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root
@@ -285,8 +288,8 @@ jobs:
     container:
       image: ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
       credentials:
-         username: ${{ secrets.GHCR_USERNAME }}
-         password: ${{ secrets.GHCR_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root

--- a/.github/workflows/dotnet.yml.j2
+++ b/.github/workflows/dotnet.yml.j2
@@ -12,6 +12,9 @@ on:
     - 'v*'
   pull_request:
 
+permissions:
+  packages: read
+
 {%- set arches = ['ppc64le', 's390x'] -%}
 
 {%- set projects = ['runtime', 'msbuild', 'roslyn', 'sdk', 'aspnetcore', 'installer'] %}
@@ -33,8 +36,8 @@ on:
     container:
       image: ghcr.io/ibm/dotnet-{% raw %}${{ matrix.arch }}{% endraw %}-toolchain:latest
       credentials:
-         username: {% raw %}${{ secrets.GHCR_USERNAME }}{% endraw %}
-         password: {% raw %}${{ secrets.GHCR_PASSWORD }}{% endraw %}
+        username: {% raw %}${{ github.actor }}{% endraw %}
+        password: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
       # Workaround for the following:
       # fatal: detected dubious ownership in repository at '/__w/dotnet-s390x/dotnet-s390x'
       options: --user root

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -12,6 +12,9 @@ on:
     - 'docker/**'
     - '.github/workflows/toolchain.yml'
 
+permissions:
+  packages: write
+
 jobs:
   toolchain:
     runs-on: ubuntu-latest
@@ -23,8 +26,8 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} docker/build -t ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest
     - name: Login
-      run: echo ${{ secrets.GHCR_PASSWORD }} |
-           docker login ghcr.io --username=${{ secrets.GHCR_USERNAME }} --password-stdin
+      run: echo ${{ secrets.GITHUB_TOKEN }} |
+           docker login ghcr.io --username=${{ github.actor }} --password-stdin
       if: ${{ github.event_name == 'push' }}
     - name: Push
       run: docker push ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest

--- a/.github/workflows/toolchain.yml.j2
+++ b/.github/workflows/toolchain.yml.j2
@@ -18,6 +18,9 @@ on:
   pull_request:
     {{- paths }}
 
+permissions:
+  packages: write
+
 jobs:
   toolchain:
     runs-on: ubuntu-latest
@@ -30,8 +33,8 @@ jobs:
     - name: Build
       run: ARCH={% raw %}${{ matrix.arch }}{% endraw %} docker/build -t {{ image }}
     - name: Login
-      run: echo {% raw %}${{ secrets.GHCR_PASSWORD }}{% endraw %} |
-           docker login ghcr.io --username={% raw %}${{ secrets.GHCR_USERNAME }}{% endraw %} --password-stdin
+      run: echo {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %} |
+           docker login ghcr.io --username={% raw %}${{ github.actor }}{% endraw %} --password-stdin
       if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
     - name: Push
       run: docker push {{ image }}


### PR DESCRIPTION
    Now that dotnet-s390x has been granted access to the toolchain images
    [1] [2] [3], GitHub Actions will provide the credentials automatically.
    
    [1] https://github.com/orgs/IBM/packages/container/dotnet-ppc64le-toolchain/settings
    [2] https://github.com/orgs/IBM/packages/container/dotnet-s390x-toolchain/settings
    [3] https://github.com/orgs/IBM/packages/container/dotnet-x64-toolchain/settings
