### PR TITLE
Downgrade upload-artifact and download-artifact to v2

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} ./dotnet-build runtime
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: runtime-${{ matrix.arch }}
         path: |
@@ -82,7 +82,7 @@ jobs:
     - name: Fix the repository ownership
       run: chown -R "$(id -u):$(id -g)" .
     - name: Download the previous stage's artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: runtime-${{ matrix.arch }}
     - name: Prepare
@@ -90,7 +90,7 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} ./dotnet-build msbuild
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: msbuild-${{ matrix.arch }}
         path: |
@@ -127,7 +127,7 @@ jobs:
     - name: Fix the repository ownership
       run: chown -R "$(id -u):$(id -g)" .
     - name: Download the previous stage's artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: msbuild-${{ matrix.arch }}
     - name: Prepare
@@ -135,7 +135,7 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} ./dotnet-build roslyn
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: roslyn-${{ matrix.arch }}
         path: |
@@ -172,7 +172,7 @@ jobs:
     - name: Fix the repository ownership
       run: chown -R "$(id -u):$(id -g)" .
     - name: Download the previous stage's artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: roslyn-${{ matrix.arch }}
     - name: Prepare
@@ -180,7 +180,7 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} ./dotnet-build aspnetcore
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: aspnetcore-${{ matrix.arch }}
         path: |
@@ -217,7 +217,7 @@ jobs:
     - name: Fix the repository ownership
       run: chown -R "$(id -u):$(id -g)" .
     - name: Download the previous stage's artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: aspnetcore-${{ matrix.arch }}
     - name: Prepare
@@ -225,7 +225,7 @@ jobs:
     - name: Build
       run: ARCH=${{ matrix.arch }} ./dotnet-build sdk
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: sdk-${{ matrix.arch }}
         path: |
@@ -256,12 +256,12 @@ jobs:
     - name: Fix the repository ownership
       run: chown -R "$(id -u):$(id -g)" .
     - name: Download the ppc64le sdk artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: sdk-ppc64le
       if: ${{ !startsWith(github.ref, 'refs/tags/v6.') }}
     - name: Download the s390x sdk artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: sdk-s390x
     - name: Create a release

--- a/.github/workflows/dotnet.yml.j2
+++ b/.github/workflows/dotnet.yml.j2
@@ -66,7 +66,7 @@ jobs:
     {{ checkout_steps }}
     {%- if i != 0 %}
     - name: Download the previous stage's artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: {{ projects[i - 1] }}-{% raw %}${{ matrix.arch }}{% endraw %}
     {%- endif %}
@@ -75,7 +75,7 @@ jobs:
     - name: Build
       run: ARCH={% raw %}${{ matrix.arch }}{% endraw %} ./dotnet-build {{ projects[i] }}
     - name: Upload the intermediate results
-      uses: actions/upload-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/upload-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: {{ projects[i] }}-{% raw %}${{ matrix.arch }}{% endraw %}
         path: |
@@ -95,7 +95,7 @@ jobs:
     {{ checkout_steps }}
     {%- for arch in arches %}
     - name: Download the {{ arch }} sdk artifacts
-      uses: actions/download-artifact@v3  # Newer versions are not compatible with Ubuntu 18.04
+      uses: actions/download-artifact@v2  # Newer versions are not compatible with Ubuntu 18.04
       with:
         name: sdk-{{ arch }}
     {%- if arch == 'ppc64le' %}


### PR DESCRIPTION
v3 is not compatible with Ubuntu 18.04 anymore.