### PR TITLE
Upgrade LLVM to version 8

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -34,7 +34,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y ca-certificates curl
 COPY fs/ /
-ARG llvm_version=7
+ARG llvm_version=8
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
         binutils-multiarch \


### PR DESCRIPTION
clang-7 cannot build zlib-ng, since it thinks that

    typedef unsigned int uv4si __attribute__((vector_size(16)));
    typedef vector unsigned int uv4si;

are different types. clang-8 does not have this issue.