### PR TITLE
add 'file' tool dependency

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
         binutils-multiarch \
         clang-$llvm_version \
         cpio \
+        file \
         gawk \
         git \
         jq \


### PR DESCRIPTION
looks like file tool is an another dependency required.
fixes the following crash

```find: 'file': No such file or directory
  find: 'file': No such file or directory
[...]
MSB4018: System.ArgumentException: An item with the same key has already been added. Key: find
[...]
MSB4018:    at Microsoft.DotNet.Build.Tasks.Installers.src.CreateRpmPackage.Execute()
```