### PR TITLE
Removed dotnet-toolset-internal.zip

### DIFF
--- a/dotnet-build
+++ b/dotnet-build
@@ -196,7 +196,9 @@ function build_sdk {
     fi
     if [ -z ${SKIP_PACKAGE_SDK+x} ] && [ ! -e .skip-package ]; then
         mkdir -p "$DOWNLOADDIR/Sdk/$SDK_VERSION"
-        cp "artifacts/packages/Release/NonShipping/dotnet-toolset-internal-$SDK_VERSION.zip" "$DOWNLOADDIR/Sdk/$SDK_VERSION"
+        if ! git merge-base --is-ancestor 140ff5e HEAD; then
+            cp "artifacts/packages/Release/NonShipping/dotnet-toolset-internal-$SDK_VERSION.zip" "$DOWNLOADDIR/Sdk/$SDK_VERSION"
+        fi
         cp "artifacts/packages/$sdk_conf/Shipping/dotnet-sdk-$SDK_VERSION-linux-$ARCH.tar.gz" "$OUTPUTDIR"
     fi
     popd


### PR DESCRIPTION
Recently the dotnet-toolset-internal.zip was removed in sdk 

https://github.com/dotnet/sdk/pull/47059