### PR TITLE
fix copy dotnet-internal-toolset.zip

### DIFF
--- a/dotnet-build
+++ b/dotnet-build
@@ -190,7 +190,7 @@ function build_sdk {
     if [ -z ${SKIP_PACKAGE_SDK+x} ] && [ ! -e .skip-package ]; then
         mkdir -p "$DOWNLOADDIR/Sdk/$SDK_VERSION"
         if git merge-base --is-ancestor 140ff5e HEAD; then
-            cp "artifacts/packages/Release/NonShipping/dotnet-toolset-internal-$SDK_VERSION.zip" "$DOWNLOADDIR/Sdk/$SDK_VERSION"
+            cp "artifacts/packages/Release/NonShipping/dotnet-toolset-internal-$SDK_VERSION-ci.zip" "$DOWNLOADDIR/Sdk/$SDK_VERSION"
         fi
         cp "artifacts/packages/$sdk_conf/Shipping/dotnet-sdk-$SDK_VERSION-linux-$ARCH.tar.gz" "$OUTPUTDIR"
     fi


### PR DESCRIPTION
Revert the minor logic change from the previous commit :- https://github.com/IBM/dotnet-s390x/pull/51
fix the package name so that this doesn't break for older release versions