### PR TITLE
Use CMake 3.28.1 on GitHub Actions to fix SDK build failure

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,7 +46,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y quilt
     - name: Prepare
-      run: ./dotnet-prepare 
+      run: ./dotnet-prepare
+    - name: Install CMake
+      run: |
+        wget https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.sh
+        chmod +x cmake-3.28.1-linux-x86_64.sh
+        sudo ./cmake-3.28.1-linux-x86_64.sh --skip-license --prefix=/usr/local
+        cmake --version
     - name: Build
       run: ARCH=${{ matrix.arch }} ./docker/run-image ghcr.io/ibm/dotnet-${{ matrix.arch }}-toolchain:latest ./dotnet-build 
     - name: Upload the intermediate results

--- a/.github/workflows/dotnet.yml.j2
+++ b/.github/workflows/dotnet.yml.j2
@@ -78,7 +78,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y quilt
     - name: Prepare
-      run: ./dotnet-prepare 
+      run: ./dotnet-prepare
+    - name: Install CMake
+      run: |
+        wget https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.sh
+        chmod +x cmake-3.28.1-linux-x86_64.sh
+        sudo ./cmake-3.28.1-linux-x86_64.sh --skip-license --prefix=/usr/local
+        cmake --version
     - name: Build
       run: ARCH={% raw %}${{ matrix.arch }}{% endraw %} ./docker/run-image {{ image }} ./dotnet-build 
     - name: Upload the intermediate results


### PR DESCRIPTION
- This PR updates the GitHub Actions workflow to explicitly install CMake 3.28.1 
- Fixes failures when building newer .NET SDK version which requires CMake ≥ 3.26 
- The default CMake version available on GitHub-hosted runners (≈ 3.23) causes the build to fail with:

>CMake 3.26 or higher is required. You are running version 3.23.x