### PR TITLE
Use CMake 3.28.1 on GitHub Actions to fix SDK build failure

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && \
         libssl-dev \
         make
 # v3.14.5+
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2.tar.gz | tar -xz
-RUN cd cmake-3.23.2 && ./bootstrap --parallel="$(nproc)"
-RUN cd cmake-3.23.2 && make -j"$(nproc)" install DESTDIR=/cmake
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1.tar.gz | tar -xz
+RUN cd cmake-3.28.1 && ./bootstrap --parallel="$(nproc)"
+RUN cd cmake-3.28.1 && make -j"$(nproc)" install DESTDIR=/cmake
 
 FROM ubuntu:18.04 as gh
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
- This PR updates the GitHub Actions workflow to explicitly install CMake 3.28.1 
- Fixes failures when building newer .NET SDK version which requires CMake ≥ 3.26 
- The default CMake version available on GitHub-hosted runners (≈ 3.23) causes the build to fail with: 

> CMake 3.26 or higher is required. You are running version 3.23.x