### PR TITLE
Backporting fix for soure-build directory change

### DIFF
--- a/dotnet-prepare
+++ b/dotnet-prepare
@@ -6,6 +6,25 @@ if git -C "$(dirname "$0")" fetch --filter=tree:0 >/dev/null 2>&1; then
     filter=(--filter=tree:0)
 fi
 
+function cherry_pick {
+    local commitid="$1"
+
+    if git cherry-pick -X theirs "$commitid"; then
+        return
+    fi
+
+    if [ "$commitid" = "e64f84d" ]; then
+        local patchfile="src/source-build-assets/src/externalPackages/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0002-Fix-assembly-version-calculation-in-2026.patch"
+
+        if git diff --name-only --diff-filter=U | grep -qx "$patchfile"; then
+            git add "$patchfile"
+            GIT_EDITOR=true git cherry-pick --continue
+            return
+        fi
+    fi
+
+}
+
 function backport {
     # Commit that introduced the bug, or an empty string.
     fixes=$1
@@ -27,7 +46,7 @@ function backport {
         if [ -e "$commitid" ]; then
             git am "$commitid"
         else
-            git cherry-pick -X theirs "$commitid"
+            cherry_pick "$commitid"
         fi
         break
     done


### PR DESCRIPTION
Newer SDK versions contain a repository layout change after source-build-reference-packages repository was renamed to source-build-assets As a result, cherry-picking e64f84d fails with a file-location conflict 

PR: https://github.com/dotnet/dotnet/pull/6044

This PR  resolves the e64f84d backport conflict caused by this migration by automatically staging the relocated patch file and continuing the cherry-pick. This remove manual conflict resolution.