### PR TITLE
Update the source-build scripts to align with recent upstream changes

### DIFF
--- a/dotnet-build
+++ b/dotnet-build
@@ -63,10 +63,10 @@ build_sdk() {
         --source-only
         --configuration Release
         --use-mono-runtime
+        --with-system-libs "+zlib+"
         --source-repository "https://github.com/dotnet/dotnet"
         --source-version "$(git -C "$DOTNETDIR" rev-parse HEAD)"
         -p:PortableBuild=true
-        -p:UseSystemLibs=all
     )
     if "$CROSS"; then
         sdk_build_flags+=(

--- a/dotnet-prepare
+++ b/dotnet-prepare
@@ -62,6 +62,7 @@ function prepare_sdk {
     else
         git fetch origin main
         backport "" e64f84d
+        backport 58d1b48 eb2c106
     fi
     popd
 }

--- a/dotnet-versions
+++ b/dotnet-versions
@@ -1,7 +1,7 @@
-runtime_version=11.0.0-alpha.1.26060.102
-sdk_version=11.0.100-alpha.1.26060.102
+runtime_version=11.0.0-preview.6.26277.116
+sdk_version=11.0.100-preview.6.26277.116
 sdk_version_prefix=11.0.100
-sdk_version_suffix=alpha.1.26060.102
+sdk_version_suffix=preview.6.26277.116
 sdk_major_version=11
 sdk_minor_version=0
-OFFICIAL_BUILD_ID=20260110.2
+OFFICIAL_BUILD_ID=20260527.16


### PR DESCRIPTION
Switch the SDK source-build configuration to use system zlib
Backport upstream fix eb2c106 ("Add mono platforms to exclude list")