### PR TITLE
Add clean-while-building flag to SDK build

### DIFF
--- a/dotnet-build
+++ b/dotnet-build
@@ -61,6 +61,7 @@ done
 build_sdk() {
     local sdk_build_flags=(
         --source-only
+        --clean-while-building
         --configuration Release
         --use-mono-runtime
         --with-system-libs "+zlib+"


### PR DESCRIPTION
recent actions runner build shows 

```
gzip: stdout: No space left on device
  tar: /home/runner/work/dotnet-s390x/dotnet-s390x/dotnet/artifacts//staging//artifacts/assets/Release/Private.SourceBuilt.Artifacts.11.0.100-preview.6.26352.110.linux-s390x.tar.gz: Wrote only 6144 of 10240 bytes
```

using this option should reduce the size ~30G

https://github.com/dotnet/source-build/blob/main/Documentation/system-requirements.md#disk-space