### PR TITLE
Backport fix for utf8_to_utf16 conversions

### DIFF
--- a/dotnet-prepare
+++ b/dotnet-prepare
@@ -63,6 +63,7 @@ function prepare_sdk {
         git fetch origin main
         backport "" e64f84d
         backport 58d1b48 eb2c106
+        backport e3357f6 a5d3b22
     fi
     popd
 }


### PR DESCRIPTION
Backport commit https://github.com/dotnet/runtime/pull/129789 which fixes some of the test case failures,

introduced in https://github.com/dotnet/runtime/pull/128577

the bug flowed into preview 6 builds.